### PR TITLE
Fix Git command not found error

### DIFF
--- a/n8n-infra/.github/workflows/deploy-to-hf.yml
+++ b/n8n-infra/.github/workflows/deploy-to-hf.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Git
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git
+
       - name: Prepare Space push payload
         id: prep
         run: |


### PR DESCRIPTION
## Sumário por Sourcery

CI:
- Instala o Git via apt-get no workflow `deploy-to-hf.yml` do GitHub Actions

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Install Git via apt-get in the GitHub Actions deploy-to-hf.yml workflow

</details>